### PR TITLE
MVP Regex Tokenizers

### DIFF
--- a/lib/tokenizer/regex/regex.ex
+++ b/lib/tokenizer/regex/regex.ex
@@ -1,2 +1,41 @@
 defmodule Woolly.Tokenizer.Regex do
+  @moduledoc ~S"""
+  A Regular-Expression based Tokenizer
+ 
+  ## Overview
+
+  The `Regex.tokenize` splits a string, or list of
+  strings using regular expressions. Regular Expression
+  based tokenizers tend to work on germanic and romantic
+  languages due to their inherit syntactical stuctures.
+
+  ## Limitations
+
+  Hand crafted patterns and finite state automata have
+  never been a flexible solution for analysing messy
+  language, which tends to be most of natural language.
+  A Regular Expression based tokenizer may not perform
+  well on human generated output such as tweets, chat
+  discussions and text messages. Lastly, language evolves
+  and due to the atomic nature, will never evolve in parellel.
+  """
+
+  def tokenize(sent) when is_binary(sent) do
+    sent = Regex.replace(~r{\.}, sent, " .")
+    sent = Regex.replace(~r{\,}, sent, " ,")
+    sent = Regex.replace(~r{\;}, sent, " ;")
+    sent = Regex.replace(~r{\?}, sent, " ?")
+    sent = Regex.replace(~r{\!}, sent, " !")
+    |> String.split()
+  end
+
+  def whitespace_tokenize(sent) when is_binary(sent) do
+    sent
+    |> String.split()
+  end
+
+  def blankline_tokenize(sent) when is_binary(sent) do
+    sent = Regex.split(~r{\n}, sent)
+    |> Enum.reject(fn(x) -> x == "" end) 
+  end
 end

--- a/test/tokenizer/regex/regex_test.exs
+++ b/test/tokenizer/regex/regex_test.exs
@@ -1,4 +1,16 @@
 defmodule Woolly.Tokenizer.RegexTest do
   use ExUnit.Case, async: true
 
+  import Woolly.Tokenizer.Regex
+
+  test :regex_tokenizer do
+    assert ["I", "am", "a", "teapot", "!"] == tokenize("I am a teapot!")
+    assert ["What", "is", "your", "name", "?"] == tokenize("What is your name?")
+    assert ["Who", "in", "the", "world", "am", "I", "?"] == tokenize("Who in the world am I?")
+    assert ["Ah", ",", "that's", "the", "great", "puzzle"] == tokenize("Ah, that's the great puzzle")
+    assert ["Curiouser", "and", "curiouser", "!"] == tokenize("Curiouser and curiouser!")
+    assert ["Have", "I", "gone", "mad", "?"] == tokenize("Have I gone mad?")
+    assert ["We're", "all", "mad", "here", "."] == tokenize("We're all mad here.")
+    assert ["Imagination", "is", "the", "only", "weapon", "in", "the", "war", "against", "reality", "."] == tokenize("Imagination is the only weapon in the war against reality.")
+  end
 end


### PR DESCRIPTION
Added an MVP of the 3 Regex Tokenizers.
- `tokenize/1`
- `whitespace_tokenize/1`
- `blankline_tokenize/1`

**Todo**
- Currently they are only implemented at a string level. They need to be working at a list and sub list level.
- `blankline_tokenize/1` has yet to be tested. `whitespace_tokenize/1` will not be tested because it bootstraps Elixirs internal `String.split`. 
